### PR TITLE
Increase pull request poll interval

### DIFF
--- a/lib/pullhub/fetchers/pull_requests_fetcher.ex
+++ b/lib/pullhub/fetchers/pull_requests_fetcher.ex
@@ -98,6 +98,6 @@ defmodule Pullhub.PullRequestsFetcher do
   end
 
   defp schedule_work do
-    Process.send_after(self(), :fetch, 30_000)
+    Process.send_after(self(), :fetch, 120_000)
   end
 end


### PR DESCRIPTION
Since we're hitting github rate limits at the moment we need to increase
the interval of polling. Going forward it will poll every two minutes