### PR TITLE
let's sort the repositories

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -17,3 +17,5 @@ config :pullhub, Pullhub.Repo,
   database: "pullhub_test",
   hostname: "localhost",
   pool: Ecto.Adapters.SQL.Sandbox
+
+config :honeybadger, :environment_name, :test

--- a/test/models/repository_test.exs
+++ b/test/models/repository_test.exs
@@ -32,4 +32,9 @@ defmodule Pullhub.RepositoryTest do
     assert length(Pullhub.Repo.all(Repository)) == 1
   end
 
+  test "sort sorts the repositories" do
+    repo = %{remote_id: 10, name: "aaaalong", owner: "1", enabled: false}
+    enabled_repo = %{remote_id: 11, name: "ZZZZebra", owner: "1", enabled: true}
+    assert hd(Repository.sort([repo, enabled_repo])) == enabled_repo
+  end
 end

--- a/web/controllers/repository_controller.ex
+++ b/web/controllers/repository_controller.ex
@@ -37,6 +37,7 @@ defmodule Pullhub.RepositoryController do
     user_id(conn)
     |> Repository.user_repositories
     |> Repo.all
+    |> Repository.sort
   end
 
   defp disable_all_user_repositories(conn) do

--- a/web/models/repository.ex
+++ b/web/models/repository.ex
@@ -34,6 +34,14 @@ defmodule Pullhub.Repository do
     Repo.one(query)
   end
 
+  def sort(repositories) do
+    Enum.sort(
+      repositories, &(
+        &1.enabled > &2.enabled
+      )
+    )
+  end
+
   @doc """
   Finds repositories belonging to user with id = user_id
   """


### PR DESCRIPTION
- by `.enabled` first

før:
![screen shot 2016-11-11 at 12 48 12](https://cloud.githubusercontent.com/assets/5213037/20214235/2daaed10-a80d-11e6-8f98-de929ec797fa.png)

efter:
![screen shot 2016-11-11 at 12 48 31](https://cloud.githubusercontent.com/assets/5213037/20214243/32e3c950-a80d-11e6-9242-47bb4c15d93a.png)
