### PR TITLE
Separate queries into separate modules

### DIFF
--- a/lib/pullhub/broadcasters/pull_requests_broadcaster.ex
+++ b/lib/pullhub/broadcasters/pull_requests_broadcaster.ex
@@ -28,7 +28,6 @@ defmodule Pullhub.PullRequestsBroadcaster do
   defp prepare_for_broadcasting(repositories) do
     Enum.map(repositories, fn(repo) ->
       PullRequests.pull_requests(repo)
-      |> Repo.all
       |> map_to_structure(repo)
     end)
   end

--- a/lib/pullhub/fetchers/repo_fetcher.ex
+++ b/lib/pullhub/fetchers/repo_fetcher.ex
@@ -8,7 +8,7 @@ defmodule Pullhub.RepoFetcher do
     GenServer.cast(:repo_fetcher, {:fetch_user_github_repositories, fetch_params})
   end
 
-  def handle_cast({:fetch_user_github_repositories, fetch_params}, state) do
+  def handle_cast({:fetch_user_github_repositories, fetch_params}, _state) do
     %{user: user} = fetch_params
     {:noreply, fetch_and_update_repositories(user)}
   end
@@ -18,14 +18,14 @@ defmodule Pullhub.RepoFetcher do
   end
 
   def start_link(opts \\ []) do
-    {:ok, pid} = GenServer.start_link(__MODULE__, [], opts)
+    {:ok, _pid} = GenServer.start_link(__MODULE__, [], opts)
   end
 
   defp fetch_and_update_repositories(user) do
     user
     |> GithubApi.repositories
     |> Enum.map(&Repositories.find_or_create/1)
-    |> Repositories.sort
+    |> Repositories.Queries.sort
     |> Enum.map(&render_repository/1)
     |> broadcastChannelInfo(user)
   end

--- a/lib/pullhub/pull_requests/pull_requests.ex
+++ b/lib/pullhub/pull_requests/pull_requests.ex
@@ -1,10 +1,10 @@
 defmodule Pullhub.PullRequests do
 
+  import Pullhub.PullRequests.Queries
+
   alias Pullhub.Repository
   alias Pullhub.PullRequest
   alias Pullhub.Repo
-  import Ecto
-  import Ecto.Query
 
   def insert_pull_requests(pull_requests, %Repository{id: repo_id}) do
     pull_requests
@@ -12,25 +12,24 @@ defmodule Pullhub.PullRequests do
     |> insert_pull_requests
   end
 
-  def pull_requests(%Repository{id: repo_id}) do
-    from p in PullRequest, where: p.repository_id == ^repo_id
-  end
-
   defp insert_pull_requests(pulls) do
     pulls
     |> Enum.map(fn(pull) -> Repo.insert(pull) end)
   end
 
+  def pull_requests(%Repository{id: repo_id} = repo) do
+    repo
+    |> find_by_repository
+    |> Repo.all
+  end
+
   def remove_pull_requests(%Repository{id: repo_id} = repo) do
-    pull_requests(repo)
+    repo
+    |> find_by_repository
     |> Repo.delete_all
   end
 
   defp add_repository_id_to_pull_request(%PullRequest{} = pull, repo_id) do
     %{ pull | repository_id: repo_id }
-  end
-
-  def open_pull_requests do
-    from(p in Pullhub.PullRequest, where: p.state == "open")
   end
 end

--- a/lib/pullhub/pull_requests/queries.ex
+++ b/lib/pullhub/pull_requests/queries.ex
@@ -1,14 +1,13 @@
 defmodule Pullhub.PullRequests.Queries do
 
-  import Ecto
   import Ecto.Query
 
   alias Pullhub.Repository
   alias Pullhub.PullRequest
 
-  def open_pull_requests, do: PullRequest |> where(state: "open")
-
   def find_by_repository(%Repository{id: repo_id}) do
     PullRequest |> where([p], p.repository_id == ^repo_id)
   end
+
+  def open_pull_requests, do: PullRequest |> where(state: "open")
 end

--- a/lib/pullhub/pull_requests/queries.ex
+++ b/lib/pullhub/pull_requests/queries.ex
@@ -1,0 +1,14 @@
+defmodule Pullhub.PullRequests.Queries do
+
+  import Ecto
+  import Ecto.Query
+
+  alias Pullhub.Repository
+  alias Pullhub.PullRequest
+
+  def open_pull_requests, do: PullRequest |> where(state: "open")
+
+  def find_by_repository(%Repository{id: repo_id}) do
+    PullRequest |> where([p], p.repository_id == ^repo_id)
+  end
+end

--- a/lib/pullhub/pull_requests/sync.ex
+++ b/lib/pullhub/pull_requests/sync.ex
@@ -21,11 +21,7 @@ defmodule Pullhub.PullRequests.Sync do
   end
 
   defp enabled_user_repositories(%User{} = user) do
-    user.id
-    |> Repositories.user_repositories
-    |> Repositories.enabled_repositories
-    |> Repositories.preload_user
-    |> Repo.all
+    user.id |> Repositories.user_repos
   end
 
   defp update_stored_data({:error, message}, _) do

--- a/lib/pullhub/repo.ex
+++ b/lib/pullhub/repo.ex
@@ -1,3 +1,5 @@
 defmodule Pullhub.Repo do
   use Ecto.Repo, otp_app: :pullhub
+
+  def count(query), do: aggregate(query, :count, :id)
 end

--- a/lib/pullhub/repositories/queries.ex
+++ b/lib/pullhub/repositories/queries.ex
@@ -1,0 +1,31 @@
+defmodule Pullhub.Repositories.Queries do
+
+  import Ecto.Query
+
+  alias Pullhub.PullRequests
+  alias Pullhub.Repository
+
+  def enabled_repositories(query), do: query |> where(enabled: true)
+
+  def find_by_ids(ids), do: Repository |> where([r], r.id in ^ids)
+
+  def find_by_remote_id_and_user_id(%Repository{} = repository) do
+    Repository
+    |> where([r], r.remote_id == ^repository.remote_id and
+                  r.user_id == ^repository.user_id)
+  end
+
+  def preload_pull_requests(query) do
+    query |> preload( pull_requests: ^PullRequests.open_pull_requests)
+  end
+
+  def preload_users(query), do: query |> preload(user: :repositories)
+
+  def sort(query), do: query |> order_by([desc: :enabled, asc: :name])
+
+  def user_repositories(query, user_id), do: query |> where(user_id: ^user_id)
+  def user_repositories(user_id), do: Repository |> user_repositories(user_id)
+
+  def without_ids(query, ids), do: query |> where([r], not(r.id in ^ids))
+  def without_ids(ids), do: Repository |> without_ids(ids)
+end

--- a/lib/pullhub/repositories/queries.ex
+++ b/lib/pullhub/repositories/queries.ex
@@ -16,7 +16,7 @@ defmodule Pullhub.Repositories.Queries do
   end
 
   def preload_pull_requests(query) do
-    query |> preload( pull_requests: ^PullRequests.open_pull_requests)
+    query |> preload( pull_requests: ^PullRequests.Queries.open_pull_requests)
   end
 
   def preload_users(query), do: query |> preload(user: :repositories)

--- a/lib/pullhub/repositories/repositories.ex
+++ b/lib/pullhub/repositories/repositories.ex
@@ -3,7 +3,6 @@ defmodule Pullhub.Repositories do
   import Pullhub.Repositories.Queries
 
   alias Pullhub.Repo
-  alias Pullhub.Repositories
   alias Pullhub.Repository
 
   @doc """

--- a/lib/pullhub/repositories/repositories.ex
+++ b/lib/pullhub/repositories/repositories.ex
@@ -1,125 +1,70 @@
 defmodule Pullhub.Repositories do
 
-  alias Pullhub.Repository
+  import Pullhub.Repositories.Queries
+
   alias Pullhub.Repo
-  import Ecto
-  import Ecto.Query
+  alias Pullhub.Repositories
+  alias Pullhub.Repository
 
   @doc """
-  Finds one repository based on remote_id. If none is found it is created and returned
+  Mark all user repositories without ids to exclude as disabled
+  """
+  def disable_all_user_repositories(user_id, exluded_ids) do
+    user_id
+    |> user_repositories
+    |> enabled_repositories
+    |> without_ids(exluded_ids)
+    |> Repo.update_all(set: [enabled: false])
+  end
+
+  @doc """
+  Mark all user repositories with certain ids as enabled
+  """
+  def enable_user_repositories(user_id, repository_ids) do
+    query = repository_ids
+    |> find_by_ids
+    |> user_repositories(user_id)
+
+    query |> Repo.update_all(set: [enabled: true])
+
+    {:ok, Repo.aggregate(query, :count, :id)}
+  end
+
+  def find_by_id(id), do: Repo.get(Repository, id)
+
+  @doc """
+  Finds one repository based on remote_id. If none is found it is created and
+  returned
   """
   def find_or_create(%Repository{} = repository) do
-    query = from r in Repository,
-            where: r.remote_id == ^repository.remote_id and r.user_id == ^repository.user_id
+    query = find_by_remote_id_and_user_id(repository)
     if !Repo.one(query)  do
       Repo.insert(repository)
     end
     Repo.one(query)
   end
+  def find_or_create(repo), do: struct(Repository, repo) |> find_or_create
 
-  def find_or_create(repository) do
-    struct(Repository, repository)
-    |> find_or_create
-  end
-
-  def sort(query) do
-    from( r in query,
-      order_by: [desc: :enabled, asc: :name]
-    )
-  end
-
+  @doc """
+  Finds repositories belonging to user with id = user_id and sorts by name
+  """
   def sorted_user_repositories(user_id) do
-    user_repositories(Repository, user_id)
+    Repository
+    |> user_repositories(user_id)
     |> sort
-  end
-
-  def all(query) do
-    query |> Repo.all
+    |> Repo.all
   end
 
   @doc """
   Finds repositories belonging to user with id = user_id
   """
-  def user_repositories(user_id) do
-    user_repositories(Repository, user_id)
-  end
-
-  def user_repositories(query, user_id) do
-    from( r in Repository,
-          where: r.user_id == ^user_id
-        )
-  end
-
-  def without_ids(repo_ids) do
-    without_ids(Repository, repo_ids)
-  end
-
-  def without_ids(query, repo_ids) do
-    from( r in query,
-          where: not(r.id in ^repo_ids)
-        )
-  end
-
-  def preload_user(query) do
-    from( r in query,
-        preload: [
-          user: :repositories
-        ]
-    )
-  end
-
   def user_repos(user_id) do
-    user_id
-    |> Repositories.user_repositories
-    |> Repositories.enabled_repositories
-    |> preload_pull_requests
-    |> preload_users
-    |> Repo.all
-  end
-
-  def preload_pull_requests(query) do
-    from r in query,
-        preload: [
-          pull_requests: ^Pullhub.PullRequests.open_pull_requests,
-        ]
-  end
-
-  def preload_users(query) do
-    from r in query,
-        preload: [
-          user: :repositories
-        ]
-  end
-
-  @doc """
-  Finds repositories marked as enabled
-  """
-  def enabled_repositories(query) do
-    from( r in query,
-          where: r.enabled == true
-        )
-  end
-
-  @doc """
-  Finds repositories by a list of ids
-  """
-  def find_by_ids(repository_ids) do
-    from(r in Repository, where: r.id in ^repository_ids)
-  end
-
-  def disable_all_user_repositories(user_id, repository_ids_to_enable) do
     user_id
     |> user_repositories
     |> enabled_repositories
-    |> without_ids(repository_ids_to_enable)
-    |> Repo.update_all(set: [enabled: false])
-  end
-
-  def enable_user_repositories(user_id, repository_ids) do
-    repository_ids
-    |> find_by_ids
-    |> Repo.update_all(set: [enabled: true])
-
-    {:ok, Repo.aggregate(find_by_ids(repository_ids), :count, :id)}
+    |> preload_pull_requests
+    |> preload_users
+    |> sort
+    |> Repo.all
   end
 end

--- a/test/pull_requests/pull_requests_test.exs
+++ b/test/pull_requests/pull_requests_test.exs
@@ -1,0 +1,98 @@
+defmodule Pullhub.PullRequestsTest do
+  use Pullhub.ModelCase
+
+  alias Pullhub.User
+  alias Pullhub.Repository
+  alias Pullhub.Repositories
+  alias Pullhub.PullRequests
+  alias Pullhub.PullRequest
+
+  defp pull_request_struct do
+    %PullRequest{
+      assignees_avatars: [],
+      assignees_logins: [],
+      body: "body",
+      issue_url: "issue_url",
+      remote_id: 1232123,
+      repository_id: nil,
+      state: "state",
+      title: "title",
+      url: "html_url",
+      author_login: "user"
+    }
+  end
+
+  test "can insert pull requests" do
+    user = Pullhub.Accounts.find_or_create(%User{email: "jd@testemail.com"})
+
+    new_repo = %{remote_id: 11, name: "t", owner: "1", user_id: user.id}
+    |> Repositories.find_or_create
+
+    [pull_request_struct, pull_request_struct]
+    |> PullRequests.insert_pull_requests(new_repo)
+
+    assert Pullhub.Repo.count(PullRequest) == 2
+  end
+
+  test "can find pull requests for a given repository" do
+    user = Pullhub.Accounts.find_or_create(%User{email: "jd@testemail.com"})
+
+    new_repo = %{remote_id: 11, name: "t", owner: "1", user_id: user.id}
+    |> Repositories.find_or_create
+
+    other_repo = %{remote_id: 14, name: "s", owner: "3123", user_id: user.id}
+    |> Repositories.find_or_create
+
+    [pull_request_struct, pull_request_struct]
+    |> PullRequests.insert_pull_requests(new_repo)
+
+    [pull_request_struct]
+    |> PullRequests.insert_pull_requests(other_repo)
+
+    assert Pullhub.Repo.count(PullRequest) == 3
+    assert Pullhub.Repo.count(PullRequests.Queries.find_by_repository(new_repo)) == 2
+  end
+
+  test "can remove pull requests for a given repository" do
+    user = Pullhub.Accounts.find_or_create(%User{email: "jd@testemail.com"})
+
+    new_repo = %{remote_id: 11, name: "t", owner: "1", user_id: user.id}
+    |> Repositories.find_or_create
+
+    other_repo = %{remote_id: 14, name: "s", owner: "3123", user_id: user.id}
+    |> Repositories.find_or_create
+
+    [pull_request_struct, pull_request_struct]
+    |> PullRequests.insert_pull_requests(new_repo)
+
+    [pull_request_struct]
+    |> PullRequests.insert_pull_requests(other_repo)
+
+    PullRequests.remove_pull_requests(new_repo)
+
+    assert Pullhub.Repo.count(PullRequest) == 1
+    assert Pullhub.Repo.count(PullRequests.Queries.find_by_repository(new_repo)) == 0
+  end
+
+
+  test "can find open pull requests" do
+    user = Pullhub.Accounts.find_or_create(%User{email: "jd@testemail.com"})
+
+    new_repo = %{remote_id: 11, name: "t", owner: "1", user_id: user.id}
+    |> Repositories.find_or_create
+
+    other_repo = %{remote_id: 14, name: "s", owner: "3123", user_id: user.id}
+    |> Repositories.find_or_create
+
+    [pull_request_struct, pull_request_struct]
+    |> PullRequests.insert_pull_requests(new_repo)
+
+    [pull_request_struct]
+    |> PullRequests.insert_pull_requests(other_repo)
+
+    PullRequests.remove_pull_requests(new_repo)
+
+    assert Pullhub.Repo.count(PullRequest) == 1
+    assert Pullhub.Repo.count(PullRequests.Queries.find_by_repository(new_repo)) == 0
+  end
+end

--- a/test/pull_requests/pull_requests_test.exs
+++ b/test/pull_requests/pull_requests_test.exs
@@ -2,7 +2,6 @@ defmodule Pullhub.PullRequestsTest do
   use Pullhub.ModelCase
 
   alias Pullhub.User
-  alias Pullhub.Repository
   alias Pullhub.Repositories
   alias Pullhub.PullRequests
   alias Pullhub.PullRequest

--- a/web/channels/user_socket.ex
+++ b/web/channels/user_socket.ex
@@ -12,7 +12,7 @@ defmodule Pullhub.UserSocket do
     case Phoenix.Token.verify(socket, "user socket", token, max_age: 1209600) do
       {:ok, user_id} ->
         {:ok, assign(socket, :user, Pullhub.Accounts.find_by_id!(user_id))}
-      {:error, reason} ->
+      {:error, _reason} ->
         :error
     end
   end

--- a/web/controllers/repository_controller.ex
+++ b/web/controllers/repository_controller.ex
@@ -3,7 +3,6 @@ defmodule Pullhub.RepositoryController do
   use Pullhub.Web, :controller
 
   alias Pullhub.Repositories
-  alias Pullhub.RepositoriesService
 
   def index(conn, _params) do
     conn
@@ -15,22 +14,22 @@ defmodule Pullhub.RepositoryController do
     disable_all_user_repositories conn, repository_ids
 
     case enable_user_repositories conn, repository_ids do
-      {:ok, count} ->
+      {:ok, _count} ->
         conn
         |> put_flash(:info, "Repositories saved.")
         |> render("index.html", repositories: user_repos(conn))
-      {:error, changeset} ->
+      {:error, _changeset} ->
         conn
         |> put_flash(:error, "Repositories ERROR saving.")
         |> render("index.html", repositories: user_repos(conn))
     end
   end
 
-  def user_id(conn) do
+  defp user_id(conn) do
     conn.assigns[:current_user].id
   end
 
-  def user_repos(conn) do
+  defp user_repos(conn) do
     Repositories.sorted_user_repositories(user_id(conn))
   end
 

--- a/web/controllers/repository_controller.ex
+++ b/web/controllers/repository_controller.ex
@@ -32,7 +32,6 @@ defmodule Pullhub.RepositoryController do
 
   def user_repos(conn) do
     Repositories.sorted_user_repositories(user_id(conn))
-    |> Repositories.all
   end
 
   defp disable_all_user_repositories(conn, repository_ids_to_enable) do

--- a/web/templates/repository/index.html.eex
+++ b/web/templates/repository/index.html.eex
@@ -1,4 +1,4 @@
-<%= form_for @conn, repository_path(@conn, :create), [as: :repository], fn f -> %>
+<%= form_for @conn, repository_path(@conn, :create), [as: :repository], fn _f -> %>
 
   <div class="form-actions py-3">
     <%= submit "Save", class: "btn btn-primary" %>


### PR DESCRIPTION
So there's a clean cut between the module which hits the database and
the one containing the queries.

This also adds tests for all Repositories and PullRequests functions

Lastly the queries uses the Ecto macros now which, at least in my opinion, makes it less verbose and more readable.